### PR TITLE
ReduxSerializableCheckCorregirElError366

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -5,5 +5,8 @@ export const store = configureStore({
     reducer: {
         calendar: CalendarSlice.reducer,
         ui: uiSlice.reducer //referencía a nuestro reducer
-    }
+    },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware({
+        serializableCheck: false
+    })
 })


### PR DESCRIPTION
Este ReduxSerializablecheck es para corregir un error que manda en la consola cada vez que se hacía un click y más que nada sirve para que ese error deje de aparecer, configurando el middleware: (getDefaultMiddleware) => getDefaultMiddleware({
        serializableCheck: false
    })